### PR TITLE
Statisk path for resurser

### DIFF
--- a/ukmfestivalen.php
+++ b/ukmfestivalen.php
@@ -72,7 +72,7 @@ function UKMfestivalen_script() {
 
 	wp_enqueue_script('WPbootstrap3_js');
 	wp_enqueue_style('WPbootstrap3_css');
-	wp_enqueue_script( 'UKMfestivalen_script', plugin_dir_url(__FILE__) .'ukmfestivalen.js');
+	wp_enqueue_script( 'UKMfestivalen_script', PLUGIN_PATH .'UKMfestivalen/ukmfestivalen.js');
 	
 }
 


### PR DESCRIPTION
Bruker en final variable for å definere statisk path-en for å peke på resurser.

Deriverer fra: https://github.com/UKMNorge/UKMresources/issues/3

OBS: UKMconfig.inc.php er modifisert. Denne linjen er lagt til
"# RESOURCES PLUGIN PATH
define('PLUGIN_PATH', 'https://' . UKM_HOSTNAME . '/wp-content/plugins/');"